### PR TITLE
fix(category): Improve category mappers and API client integration

### DIFF
--- a/src/lib/mappers/category.mapper.ts
+++ b/src/lib/mappers/category.mapper.ts
@@ -1,5 +1,5 @@
 import type { Category } from '$lib/types';
-import type { CategoryDTO, ResponseDTO } from 'commercify-api-client';
+import type { CategoryDTO, ListResponseDTO, ResponseDTO } from 'commercify-api-client';
 
 export const categoryResponseMapper = (
 	dto: ResponseDTO<CategoryDTO>
@@ -8,19 +8,11 @@ export const categoryResponseMapper = (
 	success: boolean;
 	error?: string;
 } => {
-	if (!dto.data) {
+	if (!dto.success || !dto.data) {
 		return {
 			data: null,
 			success: false,
-			error: 'Category data is missing'
-		};
-	}
-
-	if (dto.error) {
-		return {
-			data: null,
-			success: false,
-			error: dto.error
+			error: dto.error || 'Category not found'
 		};
 	}
 
@@ -31,14 +23,14 @@ export const categoryResponseMapper = (
 	};
 };
 
-export const categoryListMapper = (dto: {
-	data: CategoryDTO[];
-}): { data: Category[]; success: boolean; error?: string } => {
-	if (!dto.data || !Array.isArray(dto.data)) {
+export const categoryListMapper = (
+	dto: ListResponseDTO<CategoryDTO>
+): { data: Category[]; success: boolean; error?: string } => {
+	if (!dto.success || !dto.data) {
 		return {
 			data: [],
 			success: false,
-			error: 'Category data is missing or not in the expected format'
+			error: dto.error || 'No categories found'
 		};
 	}
 

--- a/src/routes/admin/products/categories/[id]/edit/+page.server.ts
+++ b/src/routes/admin/products/categories/[id]/edit/+page.server.ts
@@ -19,7 +19,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	}
 
 	const categories = categoriesResult.data || [];
-	const category = categories.find((c: Category) => String(c.id) === String(categoryId));
+	const category: Category = categories.find((c: Category) => String(c.id) === String(categoryId));
 
 	if (!category) {
 		throw error(404, 'Category not found');
@@ -30,15 +30,16 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		{
 			name: category.name,
 			description: category.description || '',
-			parentId: category.parentId?.toString()
+			parentId: category.parentId ? String(category.parentId) : undefined
 		},
 		zod(categorySchema)
 	);
 
+	const parentOptions = categories.filter((c: Category) => String(c.id) !== String(categoryId)); // Exclude self from parent options
 	return {
 		form,
 		category,
-		categories: categories.filter((c: Category) => String(c.id) !== String(categoryId)) // Exclude self from parent options
+		categories: parentOptions
 	};
 };
 

--- a/src/routes/admin/products/categories/[id]/edit/+page.svelte
+++ b/src/routes/admin/products/categories/[id]/edit/+page.svelte
@@ -81,9 +81,8 @@
 							<Select.Root type="single" bind:value={$formData.parentId} name={props.name}>
 								<Select.Trigger {...props}>
 									{$formData.parentId
-										? data.categories.find(
-												(c: Category) => String(c.id) === String($formData.parentId)
-											)?.name
+										? data.categories.find((c: Category) => String(c.id) === $formData.parentId)
+												?.name
 										: 'Select a parent category (optional)'}
 								</Select.Trigger>
 								<Select.Content>

--- a/src/routes/admin/products/categories/new/+page.svelte
+++ b/src/routes/admin/products/categories/new/+page.svelte
@@ -81,13 +81,14 @@
 							<Select.Root type="single" bind:value={$formData.parentId} name={props.name}>
 								<Select.Trigger {...props}>
 									{$formData.parentId
-										? data.categories.find((c: Category) => c.id === $formData.parentId)?.name
+										? data.categories.find((c: Category) => String(c.id) === $formData.parentId)
+												?.name
 										: 'Select a parent category (optional)'}
 								</Select.Trigger>
 								<Select.Content>
 									<Select.Item value="">No parent (top-level category)</Select.Item>
 									{#each data.categories as category}
-										<Select.Item value={category.id}>
+										<Select.Item value={String(category.id)}>
 											{category.name}
 										</Select.Item>
 									{/each}


### PR DESCRIPTION
This pull request introduces enhancements to category management functionality, including improved mappers, expanded API client capabilities, and consistent handling of category-related data across the application. The most important changes focus on enabling category creation, refining mappers for better error handling, and ensuring consistent data formatting.

### Enhancements to mappers:
* Updated `categoryResponseMapper` in `src/lib/mappers/category.mapper.ts` to handle cases where `dto.success` is false and refined error handling for missing or invalid category data.
* Modified `categoryListMapper` in `src/lib/mappers/category.mapper.ts` to use `ListResponseDTO` and handle `dto.success` for improved error handling when fetching category lists.

### API client improvements:
* Added a `create` method to `CachedCommercifyApiClient` in `src/lib/server/commercify/api.ts` to support category creation, including cache invalidation after successful creation.
* Integrated `categoryListMapper` into the `list` method of `CachedCommercifyApiClient` for consistent category list mapping.

### Consistent handling of category data:
* Updated category selection logic in `src/routes/admin/products/categories/[id]/edit/+page.svelte` and `src/routes/admin/products/categories/new/+page.svelte` to ensure `id` values are consistently treated as strings for comparison and binding. ([src/routes/admin/products/categories/[id]/edit/+page.svelteL84-R85](diffhunk://#diff-78d06ff5dbec810655d38054bac48f87991716f770ea8a3325a58a0458cb2fe9L84-R85), [src/routes/admin/products/categories/new/+page.svelteL84-R91](diffhunk://#diff-a327c3e8eda6fb95ba9a41c79ad008f7bb3c82cea18ad1dae831194ac088ff17L84-R91))
* Adjusted `load` function in `src/routes/admin/products/categories/[id]/edit/+page.server.ts` to exclude the current category from parent options and ensure consistent formatting of `parentId`. ([src/routes/admin/products/categories/[id]/edit/+page.server.tsL33-R42](diffhunk://#diff-9ffb0be3d74a4c8e3b9dcd9ab38290c314a478e8756256757b3fc1fd4c3285e1L33-R42))